### PR TITLE
Lt 4746 integrate with mdm service to get localization files

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@ This service consumes events from the Activities producer and becomes aware of n
 - MSSQL
 - RabbitMQ broker
 - Firebase Cloud Messaging.
+- Mdm service
 
 ## Configuration
 
@@ -77,6 +78,26 @@ And the languages should be put in lowercase format. (i.e. `en`, `es`, `de`)
 
 All notification types can be found at [here](./src/Lykke.Snow.Notifications.Domain/Enums/NotificationType.cs). 
 
+
+### 3.1. Mdm Service Integration
+
+Starting from 34th release, localization files are loaded from Mdm service.
+
+In order to specify the platform key for the file that's been uploaded through Mdm Service, use the **LocalizationPlatformKey** configuration in the following configuration section.
+
+Localization files are cached in Notification Service for given amount of time. This period is 5 minutes as default, and can be adjusted within the same configuration section.
+
+```json
+{
+  "Localization": {
+    "LocalizationPlatformKey": "NotificationService",
+    "LocalizationFileCache": {
+      "ExpirationPeriod": "00:01:00"
+    }
+  }
+}
+```
+
 ### 4. Proxy
 
 Proxy is optional. Being set, it will be used for all FCM outgoing requests.
@@ -99,6 +120,21 @@ Device configurations are cached in memory. The cache is invalidated on any chan
 {
   "ConfigurationCache": {
     "ExpirationPeriod": "00:01:00"
+  }
+}
+```
+
+### 6. External Services
+
+1. Mdm Service
+
+Please specify the base url and api key for Mdm Service within the following configuration section.
+
+```json
+{
+  "MdmServiceClient": {
+    "ServiceUrl": "",
+    "ApiKey": ""
   }
 }
 ```
@@ -153,6 +189,16 @@ Settings schema is
         "RoutingKey": "",
         "ExchangeName": "",
         "IsDurable": true
+      }
+    },
+    "MdmServiceClient": {
+      "ServiceUrl": "",
+      "ApiKey": ""
+    },
+    "Localization": {
+      "LocalizationPlatformKey": "NotificationService",
+      "LocalizationFileCache": {
+        "ExpirationPeriod": "00:01:00"
       }
     }
   }

--- a/src/Lykke.Snow.Notifications.Domain/Exceptions/LocalizationFileCannotBeLoadedException.cs
+++ b/src/Lykke.Snow.Notifications.Domain/Exceptions/LocalizationFileCannotBeLoadedException.cs
@@ -1,0 +1,11 @@
+using System;
+
+namespace Lykke.Snow.Notifications.Domain.Exceptions
+{
+    public class LocalizationFileCannotBeLoadedException : Exception
+    {
+        public LocalizationFileCannotBeLoadedException(string message) : base(message)
+        {
+        }
+    }
+}

--- a/src/Lykke.Snow.Notifications.DomainServices/Lykke.Snow.Notifications.DomainServices.csproj
+++ b/src/Lykke.Snow.Notifications.DomainServices/Lykke.Snow.Notifications.DomainServices.csproj
@@ -12,6 +12,7 @@
   </ItemGroup>
   <ItemGroup>
     <PackageReference Include="Lykke.Snow.Contracts" Version="1.48.0" />
+    <PackageReference Include="Lykke.Snow.Mdm.Contracts" Version="4.2.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="6.0.3" />
   </ItemGroup>
 </Project>

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
@@ -3,7 +3,6 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Lykke.Snow.Notifications.Domain.Exceptions;
-using Lykke.Snow.Notifications.Domain.Model;
 using Lykke.Snow.Notifications.Domain.Services;
 using Microsoft.Extensions.Logging;
 
@@ -14,8 +13,6 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
         private readonly ILocalizationDataProvider _localizationDataProvider;
         private ILogger<LocalizationService> _logger;
         
-        private LocalizationData? _localizationData;
-
         public LocalizationService(ILogger<LocalizationService> logger, 
             ILocalizationDataProvider localizationDataProvider)
         {
@@ -25,8 +22,7 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
 
         public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IReadOnlyList<string> parameters)
         {
-            if(_localizationData == null)
-                _localizationData = await _localizationDataProvider.Load();
+            var localizationData = await _localizationDataProvider.Load();
             
             if(notificationType == null)
                 throw new ArgumentNullException(nameof(notificationType));
@@ -38,8 +34,8 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             {
                 language = language.ToLower();
 
-                var title = _localizationData.Titles[notificationType][language];
-                var body = _localizationData.Bodies[notificationType][language];
+                var title = localizationData.Titles[notificationType][language];
+                var body = localizationData.Bodies[notificationType][language];
                 
                 body = string.Format(body, parameters.ToArray());
                 
@@ -59,7 +55,7 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             }
             catch(FormatException)
             {
-                var ex = new LocalizationFormatException(notificationType, language, _localizationData.Bodies[notificationType][language], parameters);
+                var ex = new LocalizationFormatException(notificationType, language, localizationData.Bodies[notificationType][language], parameters);
                 _logger.LogError(ex, ex.Message);
                 throw ex;
             }

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
@@ -71,13 +71,13 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             }
             catch(JsonReaderException e)
             {
-                _logger.LogError(e, e.Message);
+                _logger.LogError(e, "Could not parse the json string into localization data.");
 
                 throw;
             }
             catch(LocalizationFileParsingException e)
             {
-                _logger.LogError(e, e.Message);
+                _logger.LogError(e, "Could not parse the json string into localization data.");
 
                 throw;
             }

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
@@ -1,0 +1,84 @@
+using System;
+using System.Threading.Tasks;
+using Lykke.Snow.Mdm.Contracts.Api;
+using Lykke.Snow.Notifications.Domain.Exceptions;
+using Lykke.Snow.Notifications.Domain.Model;
+using Lykke.Snow.Notifications.Domain.Services;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Newtonsoft.Json;
+
+namespace Lykke.Snow.Notifications.DomainServices.Services
+{
+    public class MdmLocalizationDataProvider : ILocalizationDataProvider
+    {
+        private LocalizationData? _localizationData;
+        private DateTime _lastUpdatedAt;
+
+        private readonly TimeSpan DefaultCacheExpirationPeriod = TimeSpan.FromMinutes(5);
+        private readonly ILogger<MdmLocalizationDataProvider> _logger;
+        private readonly ILocalizationFilesBinaryApi _localizationFilesBinaryApi;
+        private readonly ISystemClock _systemClock;
+        private readonly string _localizationPlatformKey;
+        private readonly TimeSpan _cacheExpirationPeriod;
+
+        public MdmLocalizationDataProvider(ILogger<MdmLocalizationDataProvider> logger,
+            ILocalizationFilesBinaryApi localizationFilesBinaryApi,
+            TimeSpan? cacheExpirationPeriod,
+            ISystemClock systemClock,
+            string localizationPlatformKey)
+        {
+            if(string.IsNullOrEmpty(localizationPlatformKey))
+                throw new ArgumentNullException(nameof(localizationPlatformKey));
+
+            _localizationPlatformKey = localizationPlatformKey;
+            _logger = logger;
+            _localizationFilesBinaryApi = localizationFilesBinaryApi;
+            _cacheExpirationPeriod = cacheExpirationPeriod ?? DefaultCacheExpirationPeriod;
+            _systemClock = systemClock;
+        }
+
+        public async Task<LocalizationData> Load()
+        {
+            if(_localizationData == null || _systemClock.UtcNow.DateTime - _lastUpdatedAt > _cacheExpirationPeriod)
+            {
+                _localizationData = await LoadFromMdm();
+                _lastUpdatedAt = _systemClock.UtcNow.DateTime;
+            }   
+            
+            return _localizationData;
+        }
+        
+        public async Task<LocalizationData> LoadFromMdm()
+        {
+            var response = await _localizationFilesBinaryApi.GetActiveLocalizationFileAsync(_localizationPlatformKey);
+            
+            if(!response.IsSuccessStatusCode)
+                throw new LocalizationFileCannotBeLoadedException($"The status code was {response.StatusCode} - Key: {_localizationPlatformKey}");
+
+            var jsonText = await response.Content.ReadAsStringAsync();
+
+            try
+            {
+                var result = JsonConvert.DeserializeObject<LocalizationData>(jsonText);
+
+                if(result == null)
+                    throw new LocalizationFileParsingException();
+
+                return result;
+            }
+            catch(JsonReaderException e)
+            {
+                _logger.LogError(e, e.Message);
+
+                throw;
+            }
+            catch(LocalizationFileParsingException e)
+            {
+                _logger.LogError(e, e.Message);
+
+                throw;
+            }
+        }
+    }
+}

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/MdmLocalizationDataProvider.cs
@@ -44,6 +44,8 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             {
                 _localizationData = await LoadFromMdm();
                 _lastUpdatedAt = _systemClock.UtcNow.DateTime;
+
+                _logger.LogDebug("Localization data has been loaded from Mdm Service and cache has been updated.");
             }   
             
             return _localizationData;

--- a/src/Lykke.Snow.Notifications/Lykke.Snow.Notifications.csproj
+++ b/src/Lykke.Snow.Notifications/Lykke.Snow.Notifications.csproj
@@ -26,6 +26,8 @@
     <PackageReference Include="AutoMapper" Version="12.0.1" />
     <PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="12.0.0" />
     <PackageReference Include="Lykke.Snow.Common.Startup" Version="3.6.0" />
+    <PackageReference Include="LykkeBiz.Common" Version="8.1.0" />
+    <PackageReference Include="LykkeBiz.HttpClientGenerator" Version="5.5.0" />
     <PackageReference Include="LykkeBiz.SettingsReader" Version="7.1.0" />
     <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="11.3.0" />
     <PackageReference Include="LykkeBiz.Snow.Cqrs" Version="2.1.0" />

--- a/src/Lykke.Snow.Notifications/Modules/ExternalServicesModule.cs
+++ b/src/Lykke.Snow.Notifications/Modules/ExternalServicesModule.cs
@@ -1,0 +1,30 @@
+using Autofac;
+using Lykke.Common.Api.Contract.Responses;
+using Lykke.HttpClientGenerator;
+using Lykke.Snow.Mdm.Contracts.Api;
+using Lykke.Snow.Notifications.Settings;
+
+namespace Lykke.Snow.Notifications.Modules
+{
+    internal class ExternalServicesModule : Module
+    {
+        private readonly NotificationServiceSettings _settings;
+
+        public ExternalServicesModule(NotificationServiceSettings settings)
+        {
+            _settings = settings;
+        }
+
+        protected override void Load(ContainerBuilder builder)
+        {
+            var mdmClientGenerator = HttpClientGenerator.HttpClientGenerator
+                .BuildForUrl(_settings.MdmServiceClient.ServiceUrl)
+                .WithServiceName<ErrorResponse>("Mdm Service")
+                .WithOptionalApiKey(_settings.MdmServiceClient.ApiKey)
+                .Create();
+            
+            
+            builder.RegisterInstance(mdmClientGenerator.Generate<ILocalizationFilesBinaryApi>());
+        }
+    }
+}

--- a/src/Lykke.Snow.Notifications/Modules/ServiceModule.cs
+++ b/src/Lykke.Snow.Notifications/Modules/ServiceModule.cs
@@ -1,16 +1,25 @@
 // Copyright (c) 2020 Lykke Corp.
 // See the LICENSE file in the project root for more information.
 
+using System;
 using Autofac;
 using Lykke.Middlewares.Mappers;
 using Lykke.Snow.Notifications.Domain.Services;
 using Lykke.Snow.Notifications.DomainServices.Services;
+using Lykke.Snow.Notifications.Settings;
 using Microsoft.Extensions.Internal;
 
 namespace Lykke.Snow.Notifications.Modules
 {
     internal class ServiceModule : Module
     {
+        private readonly NotificationServiceSettings _notificationServiceSettings;
+
+        public ServiceModule(NotificationServiceSettings notificationServiceSettings)
+        {
+            _notificationServiceSettings = notificationServiceSettings;
+        }
+
         protected override void Load(ContainerBuilder builder)
         {
             builder.RegisterType<DefaultHttpStatusCodeMapper>()
@@ -37,9 +46,10 @@ namespace Lykke.Snow.Notifications.Modules
                 .As<ILocalizationService>()
                 .SingleInstance();
 
-            builder.RegisterType<FileSystemLocalizationDataProvider>()
+            builder.RegisterType<MdmLocalizationDataProvider>()
                 .As<ILocalizationDataProvider>()
-                .WithParameter("localizationFilePath", "localization.json")
+                .WithParameter(new TypedParameter(typeof(TimeSpan?), _notificationServiceSettings.Localization.LocalizationFileCache?.ExpirationPeriod))
+                .WithParameter(new TypedParameter(typeof(string), _notificationServiceSettings.Localization.LocalizationPlatformKey))
                 .SingleInstance();
 
             builder.RegisterType<ActivityHandler>()

--- a/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
+++ b/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
@@ -6,6 +6,11 @@ namespace Lykke.Snow.Notifications.Settings
     {
         [Optional]
         public CacheSettings? LocalizationFileCache { get; set; }
+        
+        /// <summary>
+        /// The platform key used when uploading the localization file through mdm service.
+        /// </summary>
+        /// <value></value>
         public string LocalizationPlatformKey { get; set; } = "";
     }
 }

--- a/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
+++ b/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
@@ -1,0 +1,11 @@
+using Lykke.SettingsReader.Attributes;
+
+namespace Lykke.Snow.Notifications.Settings
+{
+    public class LocalizationSettings
+    {
+        [Optional]
+        public CacheSettings? LocalizationFileCache { get; set; }
+        public string LocalizationPlatformKey { get; set; } = "";
+    }
+}

--- a/src/Lykke.Snow.Notifications/Settings/NotificationServiceSettings.cs
+++ b/src/Lykke.Snow.Notifications/Settings/NotificationServiceSettings.cs
@@ -11,9 +11,15 @@ namespace Lykke.Snow.Notifications.Settings
         public CqrsSettings Cqrs { get; set; } = new CqrsSettings();
         public FcmSettings Fcm { get; set; } = new FcmSettings();
         public SubscribersSettings? Subscribers { get; set; }
+
         [Optional]
         public CacheSettings? ConfigurationCache { get; set; }
+
         [Optional]
         public ProxySettings? Proxy { get; set; }
+        
+        public ClientSettings MdmServiceClient { get; set; } = new ClientSettings();
+        
+        public LocalizationSettings Localization { get; set; } = new LocalizationSettings();
     }
 }

--- a/src/Lykke.Snow.Notifications/Startup/HostConfiguration.cs
+++ b/src/Lykke.Snow.Notifications/Startup/HostConfiguration.cs
@@ -32,8 +32,9 @@ namespace Lykke.Snow.Notifications.Startup
                 .ConfigureContainer<ContainerBuilder>((ctx, cBuilder) =>
                 {
                     // register Autofac modules here
-                    cBuilder.RegisterModule(new ServiceModule());
+                    cBuilder.RegisterModule(new ServiceModule(settings.CurrentValue.NotificationService));
                     cBuilder.RegisterModule(new NotificationsModule(settings.CurrentValue.NotificationService));
+                    cBuilder.RegisterModule(new ExternalServicesModule(settings.CurrentValue.NotificationService));
                     
                     // @atarutin: Due to a known bug in ASP.NET Core since version 3.0 ConfigureTestContainer is not
                     // being called when using WebApplicationFactory for integration testing, therefore "environment

--- a/src/Lykke.Snow.Notifications/appsettings.json
+++ b/src/Lykke.Snow.Notifications/appsettings.json
@@ -26,6 +26,16 @@
         "ExchangeName": "",
         "IsDurable": false
       }
+    },
+    "MdmServiceClient": {
+      "ServiceUrl": "http://mdm.mt.svc.cluster.local",
+      "ApiKey": ""
+    },
+    "Localization": {
+      "LocalizationPlatformKey": "",
+      "LocalizationFileCache": {
+        "ExpirationPeriod": "00:01:00"
+      }
     }
   },
   "serilog": {

--- a/src/Lykke.Snow.Notifications/appsettings.test.json
+++ b/src/Lykke.Snow.Notifications/appsettings.test.json
@@ -28,6 +28,16 @@
         "ExchangeName": "",
         "IsDurable": false
       }
+    },
+    "MdmServiceClient": {
+      "ServiceUrl": "http://mdm.mt.svc.cluster.local",
+      "ApiKey": "margintrading"
+    },
+    "Localization": {
+      "LocalizationPlatformKey": "NotificationService",
+      "LocalizationFileCache": {
+        "ExpirationPeriod": "00:01:00"
+      }
     }
   }
 }

--- a/tests/Lykke.Snow.Notifications.Tests/Fakes/LocalizationFilesBinaryApiStub.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/Fakes/LocalizationFilesBinaryApiStub.cs
@@ -1,0 +1,95 @@
+using System.Net.Http;
+using System.Threading.Tasks;
+using Lykke.Snow.Mdm.Contracts.Api;
+using Lykke.Snow.Mdm.Contracts.Models.Contracts;
+using Lykke.Snow.Mdm.Contracts.Models.Requests;
+using Lykke.Snow.Mdm.Contracts.Models.Responses;
+using Refit;
+
+namespace Lykke.Snow.Notifications.Tests.Fakes
+{
+    public class LocalizationFilesBinaryApiStub : ILocalizationFilesBinaryApi
+    {
+        public int NumOfCalls { get; private set; } = 0;
+        private string LocalizationJsonText = @"
+                {
+                    ""Titles"": {
+                        ""AccountLocked"": {
+                           ""en"": ""Account locked"", 
+                           ""es"": ""Coenta bloqueada"", 
+                           ""de"": ""Konto gesperrt"", 
+                        },
+                        ""DepositSucceeded"": {
+                           ""en"": ""Deposit Succeeded"", 
+                           ""es"": ""Depósito exitoso"", 
+                           ""de"": ""Einzahlung erfolgreich"", 
+                        }
+                    },
+                    ""Bodies"": {
+                       ""AccountLocked"": {
+                           ""en"": ""Account has been locked."",
+                           ""es"": ""La cuenta ha sido bloqueada"",
+                           ""de"": ""Konto wurde gesperrt""
+                       }, 
+                       ""DepositSucceeded"": {
+                           ""en"": ""{0}{1} has been deposited to the account {2}."",
+                           ""es"": ""{0}{1} se ha depositado en la cuenta {2}."",
+                           ""de"": ""{0}{1} wurde auf das Konto {2} eingezahlt.""
+                       } 
+                    }
+                }
+            ";
+
+        public Task<ErrorCodeResponse<LocalizationFileErrorCodesContract>> DeleteLocalizationFileAsync(string fileId, [Body] DeleteLocalizationFileRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<ErrorCodeResponse<LocalizationFileErrorCodesContract>> DeleteLocalizationFilesBatchAsync([Body] DeleteLocalizationFilesBatchRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<DiffLocalizationFileInfoResponse> DiffLocalizationFileAsync(string platform, StreamPart file)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<HttpResponseMessage> GetActiveCompiledLocalizationFileAsync(string platform, [Query] GetActiveCompiledLocalizationFileRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<HttpResponseMessage> GetActiveLocalizationFileAsync(string platform)
+        {
+            var response = new HttpResponseMessage(System.Net.HttpStatusCode.OK)
+            {
+                Content = new StringContent(LocalizationJsonText)
+            };
+            
+            NumOfCalls++;
+
+            return Task.FromResult(response);
+        }
+
+        public Task<HttpResponseMessage> GetLocalizationFileAsync(string fileId)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<PaginatedResponseContract<LocalizationFileMetadataContract>> GetLocalizationFileInfosAsync([Query] GetLocalizationFileInfoRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+
+        public Task<ErrorCodeResponse<LocalizationFileErrorCodesContract>> UploadLocalizationFileAsync(string platform, StreamPart file, [Query] UploadLocalizationFileRequest request)
+        {
+            throw new System.NotImplementedException();
+        }
+        
+        public void SetJsonResponseText(string json)
+        {
+            LocalizationJsonText = json;
+        }
+    }
+}

--- a/tests/Lykke.Snow.Notifications.Tests/LocalizationServiceTests.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/LocalizationServiceTests.cs
@@ -152,27 +152,6 @@ namespace Lykke.Snow.Notifications.Tests
 
             IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
         }
-        [Fact]
-        public async Task GetLocalizedText_ShouldCallLoad_IfLocalizationDataIsNull()
-        {
-            var mockDataProvider = new Mock<ILocalizationDataProvider>();
-            mockDataProvider.Setup(x => x.Load()).ReturnsAsync(new LocalizationData(
-                titles: new Dictionary<string, IReadOnlyDictionary<string, string>>
-                {
-                    { "any-type", new Dictionary<string, string> { { "any-lang", "any-title" } } }
-                },
-                bodies: new Dictionary<string, IReadOnlyDictionary<string, string>>
-                {
-                    { "any-type", new Dictionary<string, string> { { "any-lang", "any-body" } } }
-                }));
-
-            var sut = CreateSut(mockDataProvider.Object);
-            
-            await sut.GetLocalizedTextAsync("any-type", "any-lang", new string[]{});
-            await sut.GetLocalizedTextAsync("any-type", "any-lang", new string[]{});
-
-            mockDataProvider.Verify(x => x.Load(), Times.Once);
-        }
 
         [Theory]
         [ClassData(typeof(LocalizationHappyPathTestData))]

--- a/tests/Lykke.Snow.Notifications.Tests/MdmLocalizationDataProviderTests.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/MdmLocalizationDataProviderTests.cs
@@ -1,0 +1,280 @@
+using System;
+using System.Collections;
+using System.Collections.Generic;
+using System.Net;
+using System.Net.Http;
+using System.Reflection;
+using System.Threading.Tasks;
+using Lykke.Snow.Mdm.Contracts.Api;
+using Lykke.Snow.Notifications.Domain.Exceptions;
+using Lykke.Snow.Notifications.Domain.Model;
+using Lykke.Snow.Notifications.DomainServices.Services;
+using Lykke.Snow.Notifications.Tests.Fakes;
+using Microsoft.Extensions.Internal;
+using Microsoft.Extensions.Logging;
+using Moq;
+using Newtonsoft.Json;
+using Xunit;
+
+namespace Lykke.Snow.Notifications.Tests
+{
+    class LocalizationTestData : IEnumerable<object[]>
+    {
+        public IEnumerator<object[]> GetEnumerator()
+        {
+            const string LocalizationJsonText = @"
+                {
+                    ""Titles"": {
+                        ""AccountLocked"": {
+                           ""en"": ""Account locked"", 
+                           ""es"": ""Coenta bloqueada"", 
+                           ""de"": ""Konto gesperrt"", 
+                        },
+                        ""DepositSucceeded"": {
+                           ""en"": ""Deposit Succeeded"", 
+                           ""es"": ""Depósito exitoso"", 
+                           ""de"": ""Einzahlung erfolgreich"", 
+                        }
+                    },
+                    ""Bodies"": {
+                       ""AccountLocked"": {
+                           ""en"": ""Account has been locked."",
+                           ""es"": ""La cuenta ha sido bloqueada"",
+                           ""de"": ""Konto wurde gesperrt""
+                       }, 
+                       ""DepositSucceeded"": {
+                           ""en"": ""{0}{1} has been deposited to the account {2}."",
+                           ""es"": ""{0}{1} se ha depositado en la cuenta {2}."",
+                           ""de"": ""{0}{1} wurde auf das Konto {2} eingezahlt.""
+                       } 
+                    }
+                }
+            ";
+
+            yield return new object[] { JsonConvert.DeserializeObject<LocalizationData>(LocalizationJsonText)! };
+        }
+
+        IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
+    }
+
+    public class MdmLocalizationDataProviderTests
+    {
+        [Fact]
+        public void Initialization_ShouldThrowException_WhenPlatformKeyIsNotProvided()
+        {
+            Assert.Throws<ArgumentNullException>(() => CreateSut(localizationPlatformKeyArg: ""));
+            Assert.Throws<ArgumentNullException>(() => CreateSut(localizationPlatformKeyArg: null));
+        }
+
+        [Fact]
+        public void CacheExpirationTime_ShouldSetToDefault_WhenNotProvided()
+        {
+            var sut = CreateSut();
+            
+            var cacheExpirationPeriod = sut
+                .GetType()
+                .GetField("_cacheExpirationPeriod", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(sut);    
+            
+            var defaultCacheExpirationPeriod = sut
+                .GetType()
+                .GetField("DefaultCacheExpirationPeriod", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(sut);
+            
+            if(cacheExpirationPeriod == null)
+                throw new NullReferenceException($"{nameof(cacheExpirationPeriod)} is null");
+
+            if(defaultCacheExpirationPeriod == null)
+                throw new NullReferenceException($"{nameof(defaultCacheExpirationPeriod)} is null");
+            
+            Assert.Equal((TimeSpan) cacheExpirationPeriod, (TimeSpan) defaultCacheExpirationPeriod);
+        }
+        
+        #region Load()
+        [Fact]
+        public async Task Load_ShouldLoadLocalizationFileFromApi_IfLocalizationDataIsNotInitialized()
+        {
+            var stub = new LocalizationFilesBinaryApiStub();
+            
+            // create the class - the localization data will be null initially
+            var sut = CreateSut(stub);
+            
+            await sut.Load();
+            
+            // assert that the api has been called
+            Assert.Equal(1, stub.NumOfCalls);
+        }
+        
+        [Theory]
+        [ClassData(typeof(LocalizationTestData))]
+        public async Task Load_ShouldReturnLocalizationDataFromMemory_IfDataHasNotExpired(LocalizationData localizationData)
+        {
+            // set expiration to 1 minute
+            var expiration = new TimeSpan(0, 1, 0);
+            
+            var mockApi = new Mock<ILocalizationFilesBinaryApi>();
+            
+            var sut = CreateSut(cacheExpirationPeriodArg: expiration, localizationFilesBinaryApiArg: mockApi.Object);
+
+            // Set value for 'localizationData' private field so that it is not null
+            var dataField = typeof(MdmLocalizationDataProvider).GetField("_localizationData", BindingFlags.NonPublic | BindingFlags.Instance);
+            if(dataField == null)
+                throw new NullReferenceException($"{nameof(dataField)} is null");
+            dataField.SetValue(sut, localizationData);
+            
+            //Set 'lastUpdated' private field to simulate a fresh (30 seconds old) localizationData
+            var lastUpdatedField = typeof(MdmLocalizationDataProvider).GetField("_lastUpdatedAt", BindingFlags.NonPublic | BindingFlags.Instance);
+            if(lastUpdatedField == null)
+                throw new NullReferenceException($"{nameof(lastUpdatedField)} is null");
+            lastUpdatedField.SetValue(sut, DateTime.UtcNow.AddSeconds(-30));
+            
+            var result = await sut.Load();
+            
+            // Verify that api has not been called
+            mockApi.Verify(x => x.GetActiveLocalizationFileAsync(It.IsAny<string>()), Times.Never);
+            
+            Assert.Equal(localizationData, result);
+        }
+        
+        [Theory]
+        [ClassData(typeof(LocalizationTestData))]
+        public async Task Load_ShouldLoadLocalizationFileFromApi_IfDataHasExpired(LocalizationData localizationData)
+        {
+            // set expiration to 1 minute
+            var expiration = new TimeSpan(0, 1, 0);
+
+            var stub = new LocalizationFilesBinaryApiStub();
+
+            var sut = CreateSut(cacheExpirationPeriodArg: expiration, localizationFilesBinaryApiArg: stub);
+
+            // Set value for 'localizationData' private field so that it is not null
+            var dataField = typeof(MdmLocalizationDataProvider).GetField("_localizationData", BindingFlags.NonPublic | BindingFlags.Instance);
+            if(dataField == null)
+                throw new NullReferenceException($"{nameof(dataField)} is null");
+            dataField.SetValue(sut, localizationData);
+
+            //Set 'lastUpdated' private field to simulate a stale (90 seconds old) localizationData
+            var lastUpdatedField = typeof(MdmLocalizationDataProvider).GetField("_lastUpdatedAt", BindingFlags.NonPublic | BindingFlags.Instance);
+            if(lastUpdatedField == null)
+                throw new NullReferenceException($"{nameof(lastUpdatedField)} is null");
+            lastUpdatedField.SetValue(sut, DateTime.UtcNow.AddSeconds(-90));
+            
+            await sut.Load();
+            
+            Assert.Equal(1, stub.NumOfCalls);
+        }
+        
+
+        [Fact]
+        public async Task Load_ShouldUpdateLastUpdatedAt_AfterUpdatingTheCache()
+        {
+            var stub = new LocalizationFilesBinaryApiStub();
+            
+            var simulatedNow = new DateTime(2023, 05, 18, 14, 51, 22);
+
+            var mockSystemClock = new Mock<ISystemClock>();
+            mockSystemClock.Setup(x => x.UtcNow).Returns((DateTimeOffset)simulatedNow);
+
+            // Create the sut without (the localizationData will be null initially - so that it will load the data from API)
+            var sut = CreateSut(localizationFilesBinaryApiArg: stub, systemClockArg: mockSystemClock.Object);
+            
+            await sut.Load();
+
+            // read lastUpdatedAt value
+            var lastUpdatedAt = sut
+                .GetType()
+                .GetField("_lastUpdatedAt", System.Reflection.BindingFlags.NonPublic | System.Reflection.BindingFlags.Instance)
+                ?.GetValue(sut);
+            
+            if (lastUpdatedAt == null)
+                throw new NullReferenceException($"{nameof(lastUpdatedAt)} is null");
+            
+            Assert.Equal(simulatedNow, (DateTime) lastUpdatedAt);
+        }
+        #endregion
+        
+
+        #region LoadFromMdm()
+        [Fact]
+        public async Task LoadFromMdm_HappyPath_ShouldReturnParsedLocalizationData()
+        {
+            var stub = new LocalizationFilesBinaryApiStub();
+            
+            var sut = CreateSut(localizationFilesBinaryApiArg: stub);
+            
+            var result = await sut.LoadFromMdm();
+            
+            Assert.NotNull(result);
+            Assert.NotEmpty(result.Titles);
+            Assert.NotEmpty(result.Bodies);
+        }
+        
+        [Fact]
+        public void LoadFromMdm_ShouldThrowLocalizationFileNotFoundException_IfHttpRequestFails()
+        {
+            var mockLocaliztaionFileBinaryApi = new Mock<ILocalizationFilesBinaryApi>();
+            mockLocaliztaionFileBinaryApi.Setup(x => x.GetActiveLocalizationFileAsync(It.IsAny<string>()))
+                .ReturnsAsync(new HttpResponseMessage(HttpStatusCode.NotFound));
+            
+            var sut = CreateSut(localizationFilesBinaryApiArg: mockLocaliztaionFileBinaryApi.Object);
+            
+            Assert.ThrowsAsync<LocalizationFileCannotBeLoadedException>(() => sut.LoadFromMdm());
+        }
+
+        [Fact]
+        public async Task LoadFromMdm_ShouldThrowLocalizationFileParsingException_IfResultIsNull()
+        {
+            // setup the stub so it simulates the api returning an empty string
+            var stub = new LocalizationFilesBinaryApiStub();
+            stub.SetJsonResponseText("");
+            
+            var sut = CreateSut(localizationFilesBinaryApiArg: stub);
+            
+            await Assert.ThrowsAsync<LocalizationFileParsingException>(() => sut.LoadFromMdm());
+        }
+
+        [Fact]
+        public async Task LoadFromMdm_ShouldThrowLocalizationFileParsingException_IfJsonParsingFails()
+        {
+            // setup the stub so it returns an invalid json (not parsable into LocalizationData)
+            var stub = new LocalizationFilesBinaryApiStub();
+            stub.SetJsonResponseText(@"{""FirstName"": ""Jane"", ""LastName"": ""Doe""}");
+            
+            var sut = CreateSut(localizationFilesBinaryApiArg: stub);
+            
+            await Assert.ThrowsAsync<LocalizationFileParsingException>(() => sut.LoadFromMdm());
+        }
+
+        #endregion
+
+        private MdmLocalizationDataProvider CreateSut(ILocalizationFilesBinaryApi? localizationFilesBinaryApiArg = null,
+            TimeSpan? cacheExpirationPeriodArg = null,
+            ISystemClock systemClockArg = null,
+            string localizationPlatformKeyArg = "NotificationService")
+        {
+            var mockLogger = new Mock<ILogger<MdmLocalizationDataProvider>>();
+            
+            ILocalizationFilesBinaryApi localizationFilesBinaryApi = new Mock<ILocalizationFilesBinaryApi>().Object;
+            TimeSpan cacheExpirationPeriod = TimeSpan.FromMinutes(5);
+            ISystemClock systemClock = new SystemClock();
+            
+            if(localizationFilesBinaryApiArg != null)
+            {
+                localizationFilesBinaryApi = localizationFilesBinaryApiArg;
+            }
+            
+            if(cacheExpirationPeriodArg != null)
+            {
+                cacheExpirationPeriod = cacheExpirationPeriodArg.Value;
+            }
+            
+            if(systemClockArg != null)
+            {
+                systemClock = systemClockArg;
+            }
+            
+            return new MdmLocalizationDataProvider(mockLogger.Object, localizationFilesBinaryApi, cacheExpirationPeriodArg, systemClock,
+                localizationPlatformKey: localizationPlatformKeyArg);
+        }
+    }
+}


### PR DESCRIPTION
This PR adds new changes to load the localization file from Mdm service. 

- Registering Mdm API contracts
- Introducing new ILocalizationDataProvider -> MdmLocalizationDataProvider (with cache logic)
- Unit tests