### PR TITLE
fix(LT-4760): remove AccountId enrichments

### DIFF
--- a/src/Lykke.Snow.Notifications.DomainServices/Mapping/ActivityTypeMapping.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Mapping/ActivityTypeMapping.cs
@@ -29,12 +29,6 @@ namespace Lykke.Snow.Notifications.DomainServices.Mapping
         internal static readonly IReadOnlyDictionary<ActivityTypeContract, Func<ActivityEvent, string[]>> DescriptionEnrichments = 
             new Dictionary<ActivityTypeContract, Func<ActivityEvent, string[]>>
         {
-            {ActivityTypeContract.AccountWithdrawalSucceeded, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }},
-            {ActivityTypeContract.AccountDepositSucceeded, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }},
-            {ActivityTypeContract.AccountWithdrawalEnabled, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }},
-            {ActivityTypeContract.AccountWithdrawalDisabled, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }},
-            {ActivityTypeContract.AccountTradingEnabled, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }},
-            {ActivityTypeContract.AccountTradingDisabled, (e) => { return e.Activity.DescriptionAttributes.ToList().Append(e.Activity.AccountId).ToArray(); }}
         };
     }
 }


### PR DESCRIPTION
This PR removes the logic to insert `activity.AccountId` to the `DescriptionAttributes` manually as the activities are now being produced in a way that it'll use AccountName if applicable.