### PR TITLE
Lt 4720 add localization for push notifications parameters

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,7 +93,8 @@ Localization files are cached in Notification Service for given amount of time. 
     "LocalizationPlatformKey": "NotificationService",
     "LocalizationFileCache": {
       "ExpirationPeriod": "00:01:00"
-    }
+    },
+    "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT"]
   }
 }
 ```
@@ -199,7 +200,8 @@ Settings schema is
       "LocalizationPlatformKey": "NotificationService",
       "LocalizationFileCache": {
         "ExpirationPeriod": "00:01:00"
-      }
+      },
+      "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT"]
     }
   }
 }

--- a/README.md
+++ b/README.md
@@ -53,6 +53,18 @@ The file has the following format.
 
 ```json
 {
+  "Attributes": {
+    "BUY": {
+      "en": "Buy",
+      "es": "Comprar",
+      "de": "Kauf"
+    },
+    "SELL": {
+      "en": "Sell",
+      "es": "Vender",
+      "de": "Verkauf"
+    }
+  },
   "Titles": {
     "AccountLocked": {
       "en": "English text for notification title with {0} placeholders {1}.",
@@ -98,6 +110,14 @@ Localization files are cached in Notification Service for given amount of time. 
   }
 }
 ```
+
+### 3.2. Translating Attributes
+
+Starting from 34th release, attributes are translated. (e.g. `BUY`, `SELL`, `STOPLOSS`, `SHORT`).
+
+Please use the `Attributes` section in localization file to provide translation per language for individual attributes.
+
+To make them eligible for translation, it's required to define them in `TranslateAttributes` section in `appsettings.json`. The attributes that's not defined in `TranslateAttributes` section won't be translated.
 
 ### 4. Proxy
 

--- a/src/Lykke.Snow.Notifications.Domain/Exceptions/LocalizationFormatException.cs
+++ b/src/Lykke.Snow.Notifications.Domain/Exceptions/LocalizationFormatException.cs
@@ -5,7 +5,7 @@ namespace Lykke.Snow.Notifications.Domain.Exceptions
 {
     public class LocalizationFormatException : FormatException
     {
-        public LocalizationFormatException(string? notificationType, string? lang, string format, IReadOnlyList<string> arguments)
+        public LocalizationFormatException(string? notificationType, string? lang, string format, IList<string> arguments)
             : base(@$"The number of arguments in the template and given parameters don't match for {notificationType} - {lang}!
                 Format: {format}
                 Arguments: {string.Join(", ", arguments)}") 

--- a/src/Lykke.Snow.Notifications.Domain/Model/LocalizationData.cs
+++ b/src/Lykke.Snow.Notifications.Domain/Model/LocalizationData.cs
@@ -7,8 +7,11 @@ namespace Lykke.Snow.Notifications.Domain.Model
     {
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Titles { get; }
         public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Bodies { get; }
+        public IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> Attributes { get; }
         
-        public LocalizationData(IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> titles, IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> bodies)
+        public LocalizationData(IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> titles, 
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> bodies,
+            IReadOnlyDictionary<string, IReadOnlyDictionary<string, string>> attributes)
         {
             if(titles == null || titles.Count == 0)
                 throw new LocalizationFileParsingException();
@@ -16,8 +19,12 @@ namespace Lykke.Snow.Notifications.Domain.Model
             if(bodies == null || bodies.Count == 0)
                 throw new LocalizationFileParsingException();
             
+            if(attributes == null || attributes.Count == 0)
+                throw new LocalizationFileParsingException();
+            
             Titles = titles;
             Bodies = bodies;
+            Attributes = attributes;
         }
     }
 }

--- a/src/Lykke.Snow.Notifications.Domain/Model/LocalizationData.cs
+++ b/src/Lykke.Snow.Notifications.Domain/Model/LocalizationData.cs
@@ -19,9 +19,6 @@ namespace Lykke.Snow.Notifications.Domain.Model
             if(bodies == null || bodies.Count == 0)
                 throw new LocalizationFileParsingException();
             
-            if(attributes == null || attributes.Count == 0)
-                throw new LocalizationFileParsingException();
-            
             Titles = titles;
             Bodies = bodies;
             Attributes = attributes;

--- a/src/Lykke.Snow.Notifications.Domain/Services/ILocalizationService.cs
+++ b/src/Lykke.Snow.Notifications.Domain/Services/ILocalizationService.cs
@@ -15,6 +15,6 @@ namespace Lykke.Snow.Notifications.Domain.Services
         /// <param name="language"></param>
         /// <param name="parameters"></param>
         /// <returns></returns>
-        Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IReadOnlyList<string> parameters);
+        Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IList<string> parameters);
     }
 }

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using Lykke.Snow.Notifications.Domain.Exceptions;
+using Lykke.Snow.Notifications.Domain.Model;
 using Lykke.Snow.Notifications.Domain.Services;
 using Microsoft.Extensions.Logging;
 
@@ -11,22 +12,25 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
     public class LocalizationService : ILocalizationService
     {
         private readonly ILocalizationDataProvider _localizationDataProvider;
-        private ILogger<LocalizationService> _logger;
-        
-        public LocalizationService(ILogger<LocalizationService> logger, 
-            ILocalizationDataProvider localizationDataProvider)
+        private readonly ILogger<LocalizationService> _logger;
+        private readonly HashSet<string> _translateAttributes;
+
+        public LocalizationService(ILogger<LocalizationService> logger,
+            ILocalizationDataProvider localizationDataProvider,
+            string[] translateAttributes)
         {
             _logger = logger;
             _localizationDataProvider = localizationDataProvider;
+            _translateAttributes = new HashSet<string>(translateAttributes);
         }
 
-        public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IReadOnlyList<string> parameters)
+        public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IList<string> parameters)
         {
             var localizationData = await _localizationDataProvider.Load();
             
             if(notificationType == null)
                 throw new ArgumentNullException(nameof(notificationType));
-            
+
             if(language == null)
                 throw new ArgumentNullException(nameof(language));
 
@@ -37,6 +41,8 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
                 var title = localizationData.Titles[notificationType][language];
                 var body = localizationData.Bodies[notificationType][language];
                 
+                parameters = TranslateParametersIfApplicable(localizationData, _translateAttributes, parameters, language);
+
                 body = string.Format(body, parameters.ToArray());
                 
                 return (title, body);
@@ -44,21 +50,47 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             catch(KeyNotFoundException)
             {
                 var ex = new TranslationNotFoundException(notificationType, language);
+
                 _logger.LogError(ex, ex.Message);
+
                 throw ex;
             }
             catch(NullReferenceException)
             {
                 var ex = new TranslationNotFoundException(notificationType, language);
+
                 _logger.LogError(ex, ex.Message);
+
                 throw ex;
             }
             catch(FormatException)
             {
                 var ex = new LocalizationFormatException(notificationType, language, localizationData.Bodies[notificationType][language], parameters);
+
                 _logger.LogError(ex, ex.Message);
+
                 throw ex;
             }
+        }
+        
+        public IList<string> TranslateParametersIfApplicable(
+            LocalizationData localizationData,
+            HashSet<string> translateAttributes,
+            IList<string> parametersArg, 
+            string lang)
+        {
+            if(parametersArg == null)
+                return new List<string>();
+
+            for(int i = 0; i < parametersArg.Count; i++)
+            {
+                var p = parametersArg[i];
+                
+                if(translateAttributes.Contains(p))
+                    parametersArg[i] = localizationData.Attributes[p][lang];
+            }
+            
+            return parametersArg;
         }
     }
 }

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/LocalizationService.cs
@@ -21,7 +21,7 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
         {
             _logger = logger;
             _localizationDataProvider = localizationDataProvider;
-            _translateAttributes = new HashSet<string>(translateAttributes);
+            _translateAttributes = new HashSet<string>(translateAttributes.Select(x => x.ToUpper()));
         }
 
         public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IList<string> parameters)
@@ -85,6 +85,8 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
             for(int i = 0; i < parametersArg.Count; i++)
             {
                 var p = parametersArg[i];
+                
+                p = p.ToUpper();
                 
                 if(translateAttributes.Contains(p))
                     parametersArg[i] = localizationData.Attributes[p][lang];

--- a/src/Lykke.Snow.Notifications/Modules/ServiceModule.cs
+++ b/src/Lykke.Snow.Notifications/Modules/ServiceModule.cs
@@ -44,6 +44,7 @@ namespace Lykke.Snow.Notifications.Modules
 
             builder.RegisterType<LocalizationService>()
                 .As<ILocalizationService>()
+                .WithParameter(new TypedParameter(typeof(string[]), _notificationServiceSettings.Localization.TranslateAttributes))
                 .SingleInstance();
 
             builder.RegisterType<MdmLocalizationDataProvider>()

--- a/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
+++ b/src/Lykke.Snow.Notifications/Settings/LocalizationSettings.cs
@@ -12,5 +12,12 @@ namespace Lykke.Snow.Notifications.Settings
         /// </summary>
         /// <value></value>
         public string LocalizationPlatformKey { get; set; } = "";
+
+        /// <summary>
+        /// Not all notification attributes should be translated.
+        /// This configuration determines the attributes that are eligible for translation.
+        /// </summary>
+        /// <value></value>
+        public string[] TranslateAttributes { get; set; } = new string[] { };
     }
 }

--- a/src/Lykke.Snow.Notifications/appsettings.json
+++ b/src/Lykke.Snow.Notifications/appsettings.json
@@ -35,7 +35,8 @@
       "LocalizationPlatformKey": "",
       "LocalizationFileCache": {
         "ExpirationPeriod": "00:01:00"
-      }
+      },
+      "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT", "MARKET", "LIMIT", "STOP", "TAKEPROFIT", "STOPLOSS", "TRAILINGSTOP"]
     }
   },
   "serilog": {

--- a/src/Lykke.Snow.Notifications/appsettings.test.json
+++ b/src/Lykke.Snow.Notifications/appsettings.test.json
@@ -38,7 +38,7 @@
       "LocalizationFileCache": {
         "ExpirationPeriod": "00:01:00"
       },
-      "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT"]
+      "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT", "MARKET", "LIMIT", "STOP", "TAKEPROFIT", "STOPLOSS", "TRAILINGSTOP"]
     }
   }
 }

--- a/src/Lykke.Snow.Notifications/appsettings.test.json
+++ b/src/Lykke.Snow.Notifications/appsettings.test.json
@@ -37,7 +37,8 @@
       "LocalizationPlatformKey": "NotificationService",
       "LocalizationFileCache": {
         "ExpirationPeriod": "00:01:00"
-      }
+      },
+      "TranslateAttributes": ["BUY", "SELL", "LONG", "SHORT"]
     }
   }
 }

--- a/src/Lykke.Snow.Notifications/localization.json
+++ b/src/Lykke.Snow.Notifications/localization.json
@@ -1,4 +1,56 @@
 {
+  "Attributes": {
+    "BUY": {
+      "en":"BUY",
+      "es":"COMPRAR",
+      "de":"KAUF"
+    },
+    "SELL": {
+      "en":"SELL",
+      "es":"VENDER",
+      "de":"VERKAUF"
+    },
+    "LONG": {
+      "en":"LONG",
+      "es":"LARGO",
+      "de":""
+    },
+    "SHORT": {
+      "en":"SHORT",
+      "es":"CORTO",
+      "de":""
+    },
+    "MARKET": {
+      "en":"MARKET",
+      "es":"MERCADO",
+      "de":""
+    },
+    "LIMIT": {
+      "en":"LIMIT",
+      "es":"LIMITE",
+      "de":""
+    },
+    "STOP": {
+      "en":"STOP",
+      "es":"STOP",
+      "de":""
+    },
+    "TAKEPROFIT": {
+      "en":"TAKEPROFIT",
+      "es":"Toma de beneficios",
+      "de":""
+    },
+    "STOPLOSS": {
+      "en":"STOPLOSS",
+      "es":"Stop de pérdidas",
+      "de":""
+    },
+    "TRAILINGSTOP": {
+      "en":"",
+      "es":"",
+      "de":""
+    }
+  },
   "Titles": {
     "AccountLocked": {
       "en": "Account locked",

--- a/src/Lykke.Snow.Notifications/localization.json
+++ b/src/Lykke.Snow.Notifications/localization.json
@@ -1,54 +1,54 @@
 {
   "Attributes": {
     "BUY": {
-      "en":"BUY",
-      "es":"COMPRAR",
-      "de":"KAUF"
+      "en": "Buy",
+      "es": "Comprar",
+      "de": "Kauf"
     },
     "SELL": {
-      "en":"SELL",
-      "es":"VENDER",
-      "de":"VERKAUF"
+      "en": "Sell",
+      "es": "Vender",
+      "de": "Verkauf"
     },
     "LONG": {
-      "en":"LONG",
-      "es":"LARGO",
-      "de":""
+      "en": "Long",
+      "es": "Largo",
+      "de": "Long"
     },
     "SHORT": {
-      "en":"SHORT",
-      "es":"CORTO",
-      "de":""
+      "en": "Short",
+      "es": "Corto",
+      "de": "Short"
     },
     "MARKET": {
-      "en":"MARKET",
-      "es":"MERCADO",
-      "de":""
+      "en": "MARKET",
+      "es": "MERCADO",
+      "de": "MARKET"
     },
     "LIMIT": {
-      "en":"LIMIT",
-      "es":"LIMITE",
-      "de":""
+      "en": "LIMIT",
+      "es": "LIMITE",
+      "de": "LIMIT"
     },
     "STOP": {
-      "en":"STOP",
-      "es":"STOP",
-      "de":""
+      "en": "STOP",
+      "es": "STOP",
+      "de": "STOP"
     },
     "TAKEPROFIT": {
-      "en":"TAKEPROFIT",
-      "es":"Toma de beneficios",
-      "de":""
+      "en": "Take profit",
+      "es": "Toma de beneficios",
+      "de": "Take profit"
     },
     "STOPLOSS": {
-      "en":"STOPLOSS",
-      "es":"Stop de pérdidas",
-      "de":""
+      "en": "Stop loss",
+      "es": "Stop de pérdidas",
+      "de": "Stop loss"
     },
     "TRAILINGSTOP": {
-      "en":"",
-      "es":"",
-      "de":""
+      "en": "Trailing stop",
+      "es": "Stop dinámico",
+      "de": "Trailing stop"
     }
   },
   "Titles": {

--- a/tests/Lykke.Snow.Notifications.Tests/ActivityHandlerTests.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/ActivityHandlerTests.cs
@@ -224,7 +224,7 @@ namespace Lykke.Snow.Notifications.Tests
             notificationServiceMock.Verify(x => x.IsDeviceTargeted(It.IsAny<DeviceConfiguration>(), It.IsAny<NotificationType>()), Times.Never);
             notificationServiceMock.Verify(x => x.BuildNotificationMessage(It.IsAny<NotificationType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
             notificationServiceMock.Verify(x => x.SendNotification(It.IsAny<NotificationMessage>(), It.IsAny<string>()), Times.Never);
-            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Never);
+            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<string>>()), Times.Never);
         }
 
         [Fact]
@@ -259,7 +259,7 @@ namespace Lykke.Snow.Notifications.Tests
             notificationServiceMock.Verify(x => x.IsDeviceTargeted(It.IsAny<DeviceConfiguration>(), It.IsAny<NotificationType>()), Times.Never);
             notificationServiceMock.Verify(x => x.BuildNotificationMessage(It.IsAny<NotificationType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Never);
             notificationServiceMock.Verify(x => x.SendNotification(It.IsAny<NotificationMessage>(), It.IsAny<string>()), Times.Never);
-            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Never);
+            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<string>>()), Times.Never);
         }
 
         [Theory]
@@ -310,7 +310,7 @@ namespace Lykke.Snow.Notifications.Tests
             notificationServiceMock.Verify(x => x.IsDeviceTargeted(It.IsAny<DeviceConfiguration>(), It.IsAny<NotificationType>()), Times.Exactly(activeDeviceCount));
             notificationServiceMock.Verify(x => x.BuildNotificationMessage(It.IsAny<NotificationType>(), It.IsAny<string>(), It.IsAny<string>(), It.IsAny<Dictionary<string, string>>()), Times.Exactly(activeDeviceCount));
             notificationServiceMock.Verify(x => x.SendNotification(It.IsAny<NotificationMessage>(), It.IsAny<string>()), Times.Exactly(activeDeviceCount));
-            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IReadOnlyList<string>>()), Times.Exactly(activeDeviceCount));
+            localizationServiceMock.Verify(x => x.GetLocalizedTextAsync(It.IsAny<string>(), It.IsAny<string>(), It.IsAny<IList<string>>()), Times.Exactly(activeDeviceCount));
         }
 
         [Theory]

--- a/tests/Lykke.Snow.Notifications.Tests/Fakes/LocalizationServiceStub.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/Fakes/LocalizationServiceStub.cs
@@ -9,7 +9,7 @@ namespace Lykke.Snow.Notifications.Tests.Fakes
     {
         public int NumOfGetLocalizedTextAsyncCalls { get; private set; }
 
-        public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IReadOnlyList<string> parameters)
+        public async Task<(string, string)> GetLocalizedTextAsync(string? notificationType, string? language, IList<string> parameters)
         {
             NumOfGetLocalizedTextAsyncCalls++;
 


### PR DESCRIPTION
This PR adds code to translate parameters for 'Order Direction', 'Order Type', and 'Position Direction'

- Specify these parameters in appsettings.json so that it will only attempt to translate a parameter if the parameter specified in the configuration('BUY', 'SELL', 'LONG', 'SHORT'.. etc)

- Update localization file schema to include new 'Attributes' section ('LocalizationData')

- Add logic to translate these parameters in LocalizationService

- Unit tests