### PR TITLE
Lt 4687 update activities contracts

### DIFF
--- a/src/Lykke.Snow.Notifications.Domain/Lykke.Snow.Notifications.Domain.csproj
+++ b/src/Lykke.Snow.Notifications.Domain/Lykke.Snow.Notifications.Domain.csproj
@@ -7,7 +7,7 @@
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="Lykke.MarginTrading.Activities.Contracts" Version="1.5.0" />
+    <PackageReference Include="Lykke.MarginTrading.Activities.Contracts" Version="1.6.0" />
     <PackageReference Include="Meteor.Client" Version="1.3.0" />
     <PackageReference Include="Lykke.Snow.Common" Version="1.57.0" />
     <PackageReference Include="LykkeBiz.Common" Version="8.1.0" />

--- a/src/Lykke.Snow.Notifications.DomainServices/Services/ActivityHandler.cs
+++ b/src/Lykke.Snow.Notifications.DomainServices/Services/ActivityHandler.cs
@@ -116,10 +116,10 @@ namespace Lykke.Snow.Notifications.DomainServices.Services
 
         public static bool TryGetNotificationType(IReadOnlyDictionary<Tuple<ActivityTypeContract, OnBehalf>, NotificationType> notificationTypeMapping, 
             ActivityTypeContract activityType, 
-            bool isOnBehalf,
+            bool? isOnBehalf,
             out NotificationType type)
         {
-            var key = new Tuple<ActivityTypeContract, OnBehalf>(activityType, isOnBehalf ? OnBehalf.Yes : OnBehalf.No);
+            var key = new Tuple<ActivityTypeContract, OnBehalf>(activityType, (isOnBehalf.HasValue && isOnBehalf.Value) ? OnBehalf.Yes : OnBehalf.No);
             
             if(!notificationTypeMapping.ContainsKey(key))
             {

--- a/src/Lykke.Snow.Notifications/Lykke.Snow.Notifications.csproj
+++ b/src/Lykke.Snow.Notifications/Lykke.Snow.Notifications.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="LykkeBiz.SettingsReader" Version="7.1.0" />
     <PackageReference Include="LykkeBiz.RabbitMqBroker" Version="11.3.0" />
     <PackageReference Include="LykkeBiz.Snow.Cqrs" Version="2.1.0" />
-    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.20.0" />
+    <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.21.0" />
     <PackageReference Include="Lykke.Middlewares" Version="3.6.1" />
     <PackageReference Include="LykkeBiz.Logs.Serilog" Version="3.3.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />

--- a/tests/Lykke.Snow.Notifications.Tests/ActivityHandlerTests.cs
+++ b/tests/Lykke.Snow.Notifications.Tests/ActivityHandlerTests.cs
@@ -40,6 +40,8 @@ namespace Lykke.Snow.Notifications.Tests
             yield return new object[] { mapping, ActivityTypeContract.PositionClosing, false, NotificationType.NotSpecified, false };
             yield return new object[] { mapping, ActivityTypeContract.OrderAcceptanceAndActivation, true, NotificationType.OnBehalfOrderPlacement, true };
             yield return new object[] { mapping, ActivityTypeContract.OrderAcceptanceAndActivation, false, NotificationType.NotSpecified, false };
+            yield return new object[] { mapping, ActivityTypeContract.AccountDepositSucceeded, null, NotificationType.DepositSucceeded, true };
+            yield return new object[] { mapping, ActivityTypeContract.OrderAcceptanceAndActivation, null, NotificationType.NotSpecified, false };
         }
 
         IEnumerator IEnumerable.GetEnumerator() => GetEnumerator();
@@ -119,7 +121,7 @@ namespace Lykke.Snow.Notifications.Tests
         public void TryGetNotificationType_ShouldMapActivity_ToNotificationType(
             IReadOnlyDictionary<Tuple<ActivityTypeContract, OnBehalf>, NotificationType> mapping, 
             ActivityTypeContract activityType,
-            bool isOnBehalf,
+            bool? isOnBehalf,
             NotificationType expectedNotificationType,
             bool expectedResult)
         {


### PR DESCRIPTION
Update `Lykke.MarginTrading.Activities.Contracts` to `1.6.0` - the version which the `IsOnBehalf` field has been made nullable.