### PR TITLE
fix(LT-4871): adjust serilog configuration to output service/env info

### DIFF
--- a/src/Lykke.Snow.Notifications/Extensions/AssemblyExtensions.cs
+++ b/src/Lykke.Snow.Notifications/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using System.Linq;
+using System.Reflection;
+
+namespace Lykke.Snow.Notifications.Extensions
+{
+    internal static class AssemblyExtensions
+    {
+        public static string Attribute<T>(this ICustomAttributeProvider provider, Func<T, string> property)
+        {
+            var value = provider.GetCustomAttributes(typeof(T), false).Cast<T>().FirstOrDefault();
+            return value == null ? string.Empty : property(value);
+        }
+    }
+}

--- a/src/Lykke.Snow.Notifications/appsettings.json
+++ b/src/Lykke.Snow.Notifications/appsettings.json
@@ -55,13 +55,13 @@
             {
               "Name": "Console",
               "Args": {
-                "outputTemplate": "[{Timestamp:u}] [{Level:u3}] - {info} {Message:lj} {NewLine}{Exception}"
+                "outputTemplate": "[{Timestamp:u}] [{Level:u3}] - [{Application}:{Version}:{Environment}] - {info} {Message:lj} {NewLine}{Exception}"
               }
             },
             {
               "Name": "File",
               "Args": {
-                "outputTemplate": "[{Timestamp:u}] [{Level:u3}] - {info} {Message:lj} {NewLine}{Exception}",
+                "outputTemplate": "[{Timestamp:u}] [{Level:u3}] - [{Application}:{Version}:{Environment}] - {info} {Message:lj} {NewLine}{Exception}",
                 "path": "logs/snow/service.log",
                 "rollingInterval": "Day"
               }


### PR DESCRIPTION
This PR changes serilog configuration in order to

1. Output service bootstrapping message (currently it's missing such message while we have this for all other services)

```
[11:19:08 INF] Lykke.Snow.Notifications [1.0.1]
[11:19:08 INF] Running on: Linux 5.10.16.3-microsoft-standard-WSL2 #1 SMP Fri Apr 2 22:23:49 UTC 2021
```

2. Enrich log entries with `Application`, `Version` and `Environment` information, so that log entries will include this information as follows.

[2023-07-12 08:19:12Z] [DBG] - `[NotificationService:1.0.1:Development]` - XXX
